### PR TITLE
fix expansion of the $hosts variable

### DIFF
--- a/br
+++ b/br
@@ -46,7 +46,7 @@ while getopts "m:c:r:i:o:t:S:h" name; do
   esac
 done 
 
-if [ -z $hosts ]; then
+if [ -z "$hosts" ]; then
   if [ -e /etc/br.hosts ]; then
     hosts=`cat /etc/br.hosts`
   else


### PR DESCRIPTION
if value of $hosts contains spaces, which can be defined by
br -m "host1 host2", bash will expand it as is. So
"if [ -z $hosts ]" is expanded to "if [ -z host1 host2 ]", this is
wrong. This commit add quotes to the $hosts variable, so it is expanded
correctly.

Signed-off-by: Zhou Zheng Sheng zhshzhou@linux.vnet.ibm.com
